### PR TITLE
Add Reissue shared release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,18 @@
+name: Release gem to RubyGems.org
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Run without publishing to RubyGems"
+        type: boolean
+        default: false
+
+jobs:
+  release:
+    uses: SOFware/reissue/.github/workflows/shared-ruby-gem-release.yml@main
+    with:
+      git_user_name: "SOFware"
+      git_user_email: "github-actions[bot]@users.noreply.github.com"
+      ruby_version: "3.4"
+      dry_run: ${{ inputs.dry_run }}


### PR DESCRIPTION
## Summary

Adds `.github/workflows/release.yml`, which calls SOFware's reusable release workflow (`SOFware/reissue/.github/workflows/shared-ruby-gem-release.yml@main`). Triggered manually via **workflow_dispatch** with an optional `dry_run` toggle.

The reusable workflow:
1. Finalizes the changelog (`rake build:checksum`)
2. Detects the version from the built gem
3. Commits & pushes the finalization if needed
4. Publishes to RubyGems via **Trusted Publishing** (`rake release`)
5. Bumps the version via reissue
6. Pushes the bump directly to the default branch (or opens a PR)

This pairs with the git-trailer changelog config already in the Rakefile (`task.fragment = :git`), so a release will assemble the changelog from commit trailers automatically.

## One-time prerequisites (outside this PR)

- **RubyGems Trusted Publishing** must be configured for the `rails-plant_uml` gem on rubygems.org — add this repo + the `release.yml` workflow as a trusted publisher. No `RUBYGEMS_API_KEY` secret is needed once set up.
- Ruby is pinned to `3.4` in the caller since the repo has no `.ruby-version`/`.tool-versions` file.
- `git_user_name`/`git_user_email` are set to the org / github-actions bot for release commit attribution; adjust if you'd prefer different attribution.